### PR TITLE
Revert "Consider a new line character in the size of the record"

### DIFF
--- a/table.go
+++ b/table.go
@@ -50,7 +50,8 @@ func (table *hashTable) getRecord(number int64) ([]byte, error) {
 	}
 
 	var (
-		offset = number * int64(recordSize)
+		// +1 for new line
+		offset = number * int64(recordSize+1)
 		record = make([]byte, recordSize)
 	)
 
@@ -95,8 +96,7 @@ func (table *hashTable) getRecordSize() (int, error) {
 		return 0, err
 	}
 
-	// +1 for new line
-	table.recordSize = len(line) + 1
+	table.recordSize = len(line)
 
 	return table.recordSize, nil
 }


### PR DESCRIPTION
Reverts reconquest/shadowd#6

It seems that it breaks some functionality, please double check since it may affect other workloads you may have.

```    # evaluating command:

        ($) curl -v -X PUT -d $payload -k https://127.0.0.1:60002/t/a/b/c/d

        (eval) "curl" "-v" "-X" "PUT" "-d" "$payload" "-k" "https://127.0.0.1:60002/t/a/b/c/d"

        (<32424> stderr) 2018/05/25 14:25:04 password change declined for a/b/c/d, wrong hash: '$5$o3dq7ElJUKQKdCjK$28Q5S86xYmJGkVB5Rw40MK7OJn6.eQi4Fi9Y.41sxs2'
```