### PR TITLE
Fix getSize() of a table

### DIFF
--- a/table.go
+++ b/table.go
@@ -120,7 +120,8 @@ func (table *hashTable) getSize() (int64, error) {
 		)
 	}
 
-	table.size = stat.Size() / int64(recordSize)
+	// +1 for new line symbol in the end of the line
+	table.size = stat.Size() / int64(recordSize+1)
 
 	return table.size, nil
 }


### PR DESCRIPTION
Sorry for the last PR.

Now I fix only `getSize()` function.

All tests passed:
```
$ make test
tests/run_tests
running test suite at: /go/src/github.com/reconquest/shadowd/tests/testcases

  .................

---
17 tests (168 assertions) done successfully!
```